### PR TITLE
feat: support HTML minifier options

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ filter_optimize:
     # minify all html files
     minify: true
     excludes:
+    # options passed to @minify-html/node
+    options: {}
   # set the priority of this plugin,
   # lower means it will be executed first, default of Hexo is 10
   priority: 12
@@ -60,6 +62,21 @@ filter_optimize:
 This plugin can be disabled by `NODE_ENV` in development to boost `hexo generate`:
 ```
 export NODE_ENV=development
+```
+
+### HTML minifier options
+
+All [`@minify-html/node` options](https://docs.rs/minify-html/latest/minify_html/struct.Cfg.html) can be configured under `filter_optimize.html.options` using their snake_case names.
+
+For example, preserve explicit `<html>` and `<head>` opening tags and all closing tags while keeping HTML minification enabled:
+
+```yml
+filter_optimize:
+  html:
+    minify: true
+    options:
+      keep_html_and_head_opening_tags: true
+      keep_closing_tags: true
 ```
 
 ## Comparison

--- a/index.js
+++ b/index.js
@@ -20,7 +20,8 @@ hexo.config.filter_optimize = deepMerge({
   },
   html: {
     minify  : true,
-    excludes: []
+    excludes: [],
+    options : {}
   },
   image: {
     minify           : true,

--- a/lib/html.js
+++ b/lib/html.js
@@ -2,10 +2,11 @@ const minifyHtml = require('@minify-html/node');
 const { inExcludes } = require('./util');
 
 module.exports = function(str, path, config) {
-  const { excludes } = config.filter_optimize.html;
+  const { excludes, options } = config.filter_optimize.html;
   if (!minifyHtml || inExcludes(path, excludes)) return str;
   return minifyHtml.minify(Buffer.from(str), {
     keep_spaces_between_attributes: true,
-    keep_comments                 : true
+    keep_comments                 : true,
+    ...options
   });
 };


### PR DESCRIPTION
Allow passing custom options to @minify-html/node, such as preserving explicit <html> and <head> tags while keeping HTML minification enabled.
