### PR TITLE
ci: configure npm trusted publishing

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,24 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  npm-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+    - uses: actions/checkout@v7
+    - name: Use Node.js
+      uses: actions/setup-node@v6
+      with:
+        node-version: '24'
+        registry-url: 'https://registry.npmjs.org'
+        package-manager-cache: false
+    - run: |
+        npm install
+        npm publish


### PR DESCRIPTION
Adds a tag-triggered npm publishing workflow using GitHub Actions OIDC.

- grants only `contents: read` and `id-token: write`
- publishes with npm 11 on Node 24, without an npm token
- follows the existing trusted-publishing workflow used by `next-theme/hexo-filter-mathjax`

Validation: `npm run lint`
